### PR TITLE
ci: add release workflow triggered by pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+            artifact: clip-llm-macos-arm64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: clip-llm-windows-x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package binary (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          cp target/${{ matrix.target }}/release/clip-llm ${{ matrix.artifact }}
+          chmod +x ${{ matrix.artifact }}
+
+      - name: Package binary (Windows)
+        if: runner.os == 'Windows'
+        run: cp target/${{ matrix.target }}/release/clip-llm.exe ${{ matrix.artifact }}.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --generate-notes \
+            artifacts/clip-llm-macos-arm64/clip-llm-macos-arm64 \
+            artifacts/clip-llm-windows-x64/clip-llm-windows-x64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
-  workflow_dispatch:
+  release:
+    types: [prereleased]
 
 permissions:
   contents: write
@@ -52,23 +50,30 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}*
 
-  release:
+  publish:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
 
-      - name: Create GitHub Release
+      - name: Attach binaries to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          gh release create "$TAG" \
+          gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --title "$TAG" \
-            --generate-notes \
+            --clobber \
             artifacts/clip-llm-macos-arm64/clip-llm-macos-arm64 \
             artifacts/clip-llm-windows-x64/clip-llm-windows-x64.exe
+
+      - name: Promote to full release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release edit "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --prerelease=false


### PR DESCRIPTION
## Summary

- Add GitHub Actions release workflow (`.github/workflows/release.yml`)
- Triggered when a pre-release is created on GitHub
- Builds macOS ARM64 (`macos-14`) and Windows x64 (`windows-latest`) release binaries in parallel
- Attaches binaries to the pre-release, then promotes it to a full release

## Workflow

```
Pre-release 생성 → Build (macOS ARM64 + Windows x64) → 바이너리 첨부 → 정식 릴리즈 승격
```

## Test plan

- [ ] Create a pre-release on GitHub and verify the workflow triggers
- [ ] Verify both macOS ARM64 and Windows x64 binaries are built successfully
- [ ] Verify binaries are attached to the release
- [ ] Verify the release is promoted from pre-release to full release

https://claude.ai/code/session_01SegEqz8F1WsLv2PUsP5xeq